### PR TITLE
add feature to delete keys from output json document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ADDED
 
 - Zip compression of output data folder to save storage space
+- feature to delete temporary referenced keys from the `json` document after derivatives are applied
 
 ### CHANGED
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A valid config json file needs to be provided for the application. An example if
 
 ## Recipe
 
-A valid recipe json file needs to be provided for the application to generate documents, with two keys, `schema` and `derivatives`. An example is shown below:
+A valid recipe json file needs to be provided for the application to generate documents, with three keys, `schema`, `derivatives` and `keysToDelete`. An example is shown below:
 
 ```json
 // recipe.json
@@ -62,6 +62,9 @@ A valid recipe json file needs to be provided for the application to generate do
         "min": 1,
         "max": 5
       }
+    },
+    "temporaryIdForReference": {
+      "type": "id"
     }
   },
   "derivatives": {
@@ -69,10 +72,11 @@ A valid recipe json file needs to be provided for the application to generate do
       "type": "string-interpolation",
       "options": {
         "string": "{}-{}",
-        "referenceKeys": ["sentiment", "randomText"]
+        "referenceKeys": ["sentiment", "temporaryIdForReference"]
       }
     }
-  }
+  },
+  "keysToDelete": ["temporaryIdForReference"]
 }
 ```
 
@@ -82,9 +86,11 @@ The above example may generate the following document:
 {
   "sentiment": "Positive",
   "randomText": "how are you today",
-  "sentimentWithText": "Positive-how are you today"
+  "sentimentWithText": "Positive-ab4p2jW1Qs35Pz"
 }
 ```
+
+For examples of each key, please check out: [Schema](#schema-object), [Derivatives](#derived-values-object), [Keys To Delete](#keys-to-delete)
 
 ### Schema Object
 
@@ -844,3 +850,25 @@ Creates a date after a date field from a reference key:
 The example above creates a date from a range of 0~10 days after the date of `keyA`.
 
 ---
+
+## Keys To Delete
+
+Sometimes it may be required to add a temporary reference for derivatives. To delete these temporary references afterwards, add these keys in the `keysToDelete` array in the `recipe` object.
+
+```javascript
+// recipe.json
+{
+  "schema": {
+    ...
+    "temporaryIdForReference": {
+      "type": "id"
+    }
+  },
+  "derivatives": {
+    ...
+  },
+  "keysToDelete": ["temporaryIdForReference"]
+}
+```
+
+The example above uses a temporary ID for reference: `temporaryIdForReference`. To delete this property after the derivatives are applied, add the field to `keysToDelete` array.

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import ConfigValidator from "./ConfigValidatorClass.js";
 import DocumentFactory from "./DocumentFactoryClass.js";
 import { getTodayDate } from "./utils/dateUtils.js";
 import { writeDocumentToDir, zipFolder } from "./utils/fileUtils.js";
+import { deleteKeysFromObject } from "./utils/objectUtils.js";
 
 async function init() {
   const uniqueFolderId = uuidv4();
@@ -13,7 +14,7 @@ async function init() {
   const { recipeFilePath, nullablePercentage, documentCount, outputDir, references } = configJson;
 
   const recipeFile = JSON.parse(fs.readFileSync(recipeFilePath));
-  const { schema, derivatives } = recipeFile;
+  const { schema, derivatives, keysToDelete } = recipeFile;
   const destinationFolder = path.join(outputDir, getTodayDate(), uniqueFolderId);
 
   console.info(`Successfully retrieved recipe from: '${recipeFilePath}'. Performing validation...`);
@@ -35,13 +36,17 @@ async function init() {
   );
 
   for (let i = 0; i < documentCount; i++) {
-    const newDocument = new DocumentFactory(
+    let document = new DocumentFactory(
       schema,
       nullablePercentage,
       references,
       derivatives,
     ).getDocument();
-    writeDocumentToDir(destinationFolder, newDocument);
+
+    // delete keys from final object if any
+    document = deleteKeysFromObject(document, keysToDelete);
+
+    writeDocumentToDir(destinationFolder, document);
   }
 
   // zip and delete folder afterwards

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -1,0 +1,11 @@
+export function deleteKeysFromObject(object, keysToDelete) {
+  const objectCopy = JSON.parse(JSON.stringify(object));
+
+  if (keysToDelete && keysToDelete.length > 0) {
+    keysToDelete.forEach((keyToDelete) => {
+      delete objectCopy[keyToDelete];
+    });
+  }
+
+  return objectCopy;
+}

--- a/tests/utils/objectUtils.spec.js
+++ b/tests/utils/objectUtils.spec.js
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+
+import { deleteKeysFromObject } from "../../src/utils/objectUtils.js";
+
+describe("Testing utility function: deleteKeysFromObject", function () {
+  let counter = 0;
+
+  it(`${++counter}. Given an object with 2 properties and 1 property to delete, it should return the correct object`, function () {
+    const inputObject = { test1: 1, test2: 1 };
+    const keysToDelete = ["test1"];
+
+    const result = deleteKeysFromObject(inputObject, keysToDelete);
+
+    expect(result).to.eql({ test2: 1 });
+  });
+
+  it(`${++counter}. Given an object with 2 properties and 2 properties to delete, it should return the correct object`, function () {
+    const inputObject = { test1: 1, test2: 1 };
+    const keysToDelete = ["test1", "test2"];
+
+    const result = deleteKeysFromObject(inputObject, keysToDelete);
+
+    expect(result).to.eql({});
+  });
+
+  it(`${++counter}. Given an object with 2 properties and 0 properties to delete, it should return the correct object`, function () {
+    const inputObject = { test1: 1, test2: 1 };
+    const keysToDelete = [];
+
+    const result = deleteKeysFromObject(inputObject, keysToDelete);
+
+    expect(result).to.eql({ test1: 1, test2: 1 });
+  });
+
+  it(`${++counter}. Given an object with 2 properties and invalid properties to delete, it should return the correct object`, function () {
+    const inputObject = { test1: 1, test2: 1 };
+    const keysToDelete = ["invalidKey1"];
+
+    const result = deleteKeysFromObject(inputObject, keysToDelete);
+
+    expect(result).to.eql({ test1: 1, test2: 1 });
+  });
+});


### PR DESCRIPTION
### ADDED

- feature to delete temporary referenced keys from the `json` document after derivatives are applied